### PR TITLE
chore: make ID type strict

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ const Query = t.queryType({
     t.field('userById', {
       type: UserType,
       args: {
-        id: t.arg(t.NonNullInput(t.IDString)),
+        id: t.arg(t.NonNullInput(t.ID)),
       },
       resolve: (_, args, ctx) => {
         // `args` is automatically inferred as { id: string }

--- a/examples/starwars.ts
+++ b/examples/starwars.ts
@@ -1,4 +1,4 @@
-import { createTypesFactory, buildGraphQLSchema } from '../dist';
+import { createTypesFactory, buildGraphQLSchema } from '../src';
 
 const t = createTypesFactory<{ contextContent: string }>();
 
@@ -16,21 +16,13 @@ type ICharacter = {
   appearsIn: Array<Episode>;
 };
 
-type Human = {
+type Human = ICharacter & {
   type: 'Human';
-  id: string;
-  name: string;
-  friends: Array<string>;
-  appearsIn: Array<Episode>;
   homePlanet: string | null;
 };
 
-type Droid = {
+type Droid = ICharacter & {
   type: 'Droid';
-  id: string;
-  name: string;
-  friends: Array<string>;
-  appearsIn: Array<Episode>;
   primaryFunction: string;
 };
 
@@ -148,7 +140,7 @@ const episodeEnum = t.enumType({
 const characterInterface = t.interfaceType<ICharacter>({
   name: 'Character',
   fields: (self) => [
-    t.abstractField('id', t.NonNull(t.IDString)),
+    t.abstractField('id', t.NonNull(t.ID)),
     t.abstractField('name', t.NonNull(t.String)),
     t.abstractField('appearsIn', t.NonNull(t.List(t.NonNull(episodeEnum)))),
     t.abstractField('friends', t.NonNull(t.List(self))),
@@ -186,7 +178,7 @@ const droidType = t.objectType<Droid>({
   interfaces: [characterInterface],
   isTypeOf: (thing: ICharacter) => thing.type === 'Droid',
   fields: () => [
-    t.defaultField('id', t.NonNull(t.IDString)),
+    t.defaultField('id', t.NonNull(t.ID)),
     t.defaultField('name', t.NonNull(t.String)),
     t.defaultField('appearsIn', t.NonNull(t.List(t.NonNull(episodeEnum)))),
     t.defaultField('primaryFunction', t.NonNull(t.String)),

--- a/src/define.ts
+++ b/src/define.ts
@@ -33,9 +33,7 @@ export function createTypesFactory<Ctx = undefined>() {
     Int: builtInScalar<number>(graphql.GraphQLInt),
     Float: builtInScalar<number>(graphql.GraphQLFloat),
     Boolean: builtInScalar<boolean>(graphql.GraphQLBoolean),
-    ID: builtInScalar<any>(graphql.GraphQLID),
-    IDString: builtInScalar<string>(graphql.GraphQLID),
-    IDInt: builtInScalar<number>(graphql.GraphQLID),
+    ID: builtInScalar<string>(graphql.GraphQLID),
     scalarType<Src>({
       name,
       description,


### PR DESCRIPTION
Closes #11 

I think this should considered as a breaking change because TS gives error when using `t.ID` and the field type is only `string` or `number`.

> Argument of type 'string | number' is not assignable to parameter of type 'string'.
  Type 'number' is not assignable to type 'string'.ts(2345)
