### PR TITLE
fix: remove optional chaining

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -23,7 +23,7 @@ export function buildGraphQLSchema<Ctx, RootSrc>(
         Ctx
       >),
     subscription: schema.subscription && toGraphQLSubscriptionObject(schema.subscription, typeMap),
-    types: schema.types?.map((type) => toGraphQOutputType(type, typeMap) as graphql.GraphQLObjectType<any, any>)
+    types: schema.types && schema.types.map((type) => toGraphQOutputType(type, typeMap) as graphql.GraphQLObjectType<any, any>)
   });
 }
 


### PR DESCRIPTION
Currently the supported version of TS is `3.6.4`, but optional chaining was added in `3.7`.