### PR TITLE
deps: update graphql to v15 + interfaces can implement interfaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,12 +20,12 @@
     "@types/express": "^4.17.1",
     "express": "^4.17.1",
     "express-graphql": "^0.9.0",
-    "graphql": "^14.5.8",
+    "graphql": "^15.1.0",
     "ts-node": "^8.4.1",
     "typescript": "^3.6.4"
   },
-  "dependencies": {
-    "graphql": "^14.5.8"
+  "peerDependencies": {
+    "graphql": "^15.1.0"
   },
   "scripts": {
     "prepare": "tsc"

--- a/src/build.ts
+++ b/src/build.ts
@@ -215,6 +215,7 @@ export function toGraphQLOutputType<Ctx, Src>(
 
           return result;
         },
+        interfaces: t.interfaces.map((intf) => toGraphQLOutputType(intf, typeMap)) as any,
       });
 
       typeMap.set(t, intf);

--- a/src/define.ts
+++ b/src/define.ts
@@ -222,16 +222,19 @@ export function createTypesFactory<Ctx = undefined>() {
     interfaceType<Src>({
       name,
       description,
+      interfaces = [],
       fields,
     }: {
       name: string;
       description?: string;
+      interfaces?: Array<Interface<Ctx, any>>;
       fields: (self: Interface<Ctx, Src | null>) => Array<AbstractField<Ctx, any>>;
     }): Interface<Ctx, Src | null> {
       const obj: Interface<Ctx, Src | null> = {
         kind: 'Interface',
         name,
         description,
+        interfaces,
         fieldsFn: undefined as any,
       };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -153,6 +153,7 @@ export type Interface<Ctx, Src> = {
   kind: 'Interface';
   name: string;
   description?: string;
+  interfaces: Array<Interface<Ctx, any>>;
   fieldsFn: () => Array<AbstractField<Ctx, any>>;
   resolveType?: ResolveType<Src, Ctx>;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -234,12 +234,10 @@ fresh@0.5.2:
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
 
-graphql@^14.5.8:
-  version "14.5.8"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.5.8.tgz#504f3d3114cb9a0a3f359bbbcf38d9e5bf6a6b3c"
-  integrity sha512-MMwmi0zlVLQKLdGiMfWkgQD7dY/TUKt4L+zgJ/aR0Howebod3aNgP5JkgvAULiR2HPVZaP2VEElqtdidHweLkg==
-  dependencies:
-    iterall "^1.2.2"
+graphql@^15.1.0:
+  version "15.1.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.1.0.tgz#b93e28de805294ec08e1630d901db550cb8960a1"
+  integrity sha512-0TVyfOlCGhv/DBczQkJmwXOK6fjWkjzY3Pt7wY8i0gcYXq8aogG3weCsg48m72lywKSeOqedEHvVPOvZvSD51Q==
 
 http-errors@1.7.2:
   version "1.7.2"
@@ -284,11 +282,6 @@ ipaddr.js@1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.0.tgz#37df74e430a0e47550fe54a2defe30d8acd95f65"
   integrity sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA==
-
-iterall@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.2.2.tgz#92d70deb8028e0c39ff3164fdbf4d8b088130cd7"
-  integrity sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA==
 
 make-error@^1.1.1:
   version "1.3.5"


### PR DESCRIPTION
https://github.com/graphql/graphql-js/releases/tag/v15.0.0

- moves graphql to `peerDependencies`, which makes it easier to use a newer version (`15.x.x`)
- add support for specifying interfaces on interface types (see https://github.com/graphql/graphql-js/pull/2084)

I also created my own private release with these changes for testing whether any stuff breaks (https://www.npmjs.com/package/@n1ru4l/gqtx). I did not notice any issues yet.

In addition, I would really appreciate a new release after merging this. 😊


closes https://github.com/sikanhe/gqtx/issues/19
