### PR TITLE
fix: non required argument can be undefined if it is not provided at …

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -88,10 +88,14 @@ export type ArgMap<T> = {
   [K in keyof T]: DefaultArgument<T[K]> | Argument<T[K]>;
 };
 
+export type ArgMapValue<TArg> = TArg extends DefaultArgument<infer Src>
+? Src
+  : TArg extends Argument<infer Src>
+  ? Src extends null ? Maybe<Src> : Src
+: never
+
 export type TOfArgMap<TArgMap> = {
-  [K in keyof TArgMap]: TArgMap[K] extends DefaultArgument<infer Src> | Argument<infer Src>
-    ? Src
-    : never;
+  [K in keyof TArgMap]: ArgMapValue<TArgMap[K]>
 };
 
 export type Field<Ctx, Src, Out, TArg extends object = {}> = {


### PR DESCRIPTION
…all and has no default value.

closes https://github.com/sikanhe/gqtx/issues/34


```graphql
type Query {
  foo(a: String): Boolean
}
```

```graphql
query foo {
  foo
}
```

For the following query on the given schema, the actual runtime type in the resolver for the `a` argument is `undefined`. It is only `null` if the argument is explicitly set to `null`, either via a default argument, or variable.

I guess this makes sense as in your resolvers you might have a database calls that updates a value that is either a string or null. If the argument is undefined that means the value must not be updated.