### PR TITLE
feat: field extensions

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -182,6 +182,7 @@ export function toGraphQLOutputType<Ctx, Src>(
 
           return gqlFieldConfig;
         },
+        extensions: t.extensions,
       });
 
       typeMap.set(t, obj);

--- a/src/build.ts
+++ b/src/build.ts
@@ -176,6 +176,7 @@ export function toGraphQLOutputType<Ctx, Src>(
               resolve: field.resolve,
               args: toGraphQLArgs(field.args, typeMap),
               deprecationReason: field.deprecationReason,
+              extensions: field.extensions
             } as graphql.GraphQLFieldConfig<unknown, Ctx, any>;
           });
 

--- a/src/define.ts
+++ b/src/define.ts
@@ -62,6 +62,7 @@ export type Factory<Ctx> = {
       resolve,
       description,
       deprecationReason,
+      extensions
     }: {
       type: OutputType<Ctx, Out>;
       args?: ArgMap<Arg> | undefined;
@@ -73,6 +74,7 @@ export type Factory<Ctx> = {
         ctx: Ctx,
         info: graphql.GraphQLResolveInfo
       ) => Out | Promise<Out>;
+      extensions?: Record<string, any>;
     }
   ): Field<Ctx, Src, any, any>;
   defaultField<Src extends object, K extends keyof Src>(
@@ -276,6 +278,7 @@ export function createTypesFactory<Ctx = undefined>(): Factory<Ctx> {
         resolve,
         description,
         deprecationReason,
+        extensions
       }: {
         type: OutputType<Ctx, Out>;
         args?: ArgMap<Arg>;
@@ -287,6 +290,7 @@ export function createTypesFactory<Ctx = undefined>(): Factory<Ctx> {
           ctx: Ctx,
           info: graphql.GraphQLResolveInfo
         ) => Out | Promise<Out>;
+        extensions?: Record<string, any>
       }
     ): Field<Ctx, Src, any, any> {
       return {
@@ -297,6 +301,7 @@ export function createTypesFactory<Ctx = undefined>(): Factory<Ctx> {
         deprecationReason,
         args,
         resolve,
+        extensions
       };
     },
     defaultField<Src extends object, K extends keyof Src>(

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -48,7 +48,7 @@ export type RelayConnectionDefinitions<Ctx, T> = {
   connectionType: ObjectType<Ctx, Connection<T>>;
 };
 
-export function createRelayHelpers<Ctx>(t: Factory<Ctx>) {
+export function createRelayHelpers<Ctx, ExtensionsMap>(t: Factory<Ctx, ExtensionsMap>) {
   function nodeDefinitions<Src>(
     idFetcher: (id: string, context: Ctx, info: GraphQLResolveInfo) => Promise<Src> | Src
   ) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -107,6 +107,7 @@ export type Field<Ctx, Src, Out, TArg extends object = {}> = {
     ctx: Ctx,
     info: graphql.GraphQLResolveInfo
   ) => Out | Promise<Out>;
+  extensions?: Record<string, any>;
 };
 
 export type AbstractField<Ctx, Out> = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -126,6 +126,7 @@ export type ObjectType<Ctx, Src> = {
   interfaces: Array<Interface<Ctx, any>>;
   fieldsFn: () => Array<Field<Ctx, Src, any, any>>;
   isTypeOf?: (src: any, ctx: Ctx, info: graphql.GraphQLResolveInfo) => boolean | Promise<boolean>;
+  extensions?: Record<string, any>;
 };
 
 export type InputField<Src> = {


### PR DESCRIPTION
```ts
type GraphQLExtensions = {
  field: {
    liveQuery?: {
      collectResourceIdentifiers: (
        src: any,
        args: any
      ) => Iterable<string> | string | null;
    };
  };
};

export const t = createTypesFactory<GraphQLContextType, GraphQLExtensions>();

t.field("note", {
  type: GraphQLNoteType,
  args: {
    documentId: t.arg(t.NonNullInput(t.ID))
  },
  extensions: {
    liveQuery: {
      collectResourceIdentifiers: (_: any, args: any) =>
        `Note:${args.documentId}`
    }
  },
  resolve: (_, args, context) => RT.run(resolveNote(args.documentId), context)
});
```

This allows typing the available extensions for `t.field` and `t.objectType`. I have not figured out whether it would be possible to also make the arguments of the extensions field depending on the provided arguments. For E.g. my `liveQuery.collectResourceIdentifiers` implementation always calls the function with the source object and the args. However other extensions could do something completely different. @sikanhe Please let me know what you think.