### PR TITLE
Use `unknown` instead of `JSON` for `parseValue` in `scalarType`

### DIFF
--- a/src/define.ts
+++ b/src/define.ts
@@ -47,7 +47,7 @@ export type Factory<Ctx, TExtensionsMap extends ExtensionsMap > = {
     name: string;
     description?: string | undefined;
     serialize: (src: Src) => any;
-    parseValue?: ((value: JSON) => Src | null) | undefined;
+    parseValue?: ((value: unknown) => Src | null) | undefined;
     parseLiteral?: ((value: graphql.ValueNode) => Src | null) | undefined;
   }): Scalar<Src | null>;
   enumType<Src>({
@@ -233,7 +233,7 @@ export function createTypesFactory<Ctx = undefined, TExtensions extends Extensio
       name: string;
       description?: string;
       serialize: (src: Src) => any | null;
-      parseValue?: (value: JSON) => Src | null;
+      parseValue?: (value: unknown) => Src | null;
       parseLiteral?: (value: graphql.ValueNode) => Src | null;
     }): Scalar<Src | null> {
       return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,7 +30,7 @@ export type AllType<Ctx> = OutputType<Ctx, any> | InputType<any>;
 export type Scalar<Src> =
   | {
       kind: 'Scalar';
-      graphqlTypeConfig: graphql.GraphQLScalarTypeConfig<Src, JSON>;
+      graphqlTypeConfig: graphql.GraphQLScalarTypeConfig<Src, unknown>;
     }
   | {
       kind: 'Scalar';


### PR DESCRIPTION
Hi! We're testing `gqtx` as a replacement for `nexus` and while migrating our scalar types I found that `parseValue` expects a value of type `JSON` (any object with a `.toString()` method AFAICT). I'm not sure if this is because I need to define my scalars differently or it is simply the `JSON` type being weird.

For now I've explicitly set the input type to unknown, and this PR does the same. Please let me know if this makes sense at all or I should be doing something else. 😃 