### PR TITLE
pass args to abstract fields/interface fields

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -217,6 +217,7 @@ export function toGraphQLOutputType<Ctx, Src>(
               type: toGraphQLOutputType(field.type, typeMap),
               description: field.description,
               deprecationReason: field.deprecationReason,
+              args: field.args && toGraphQLArgs(field.args, typeMap)
             };
           });
 

--- a/src/define.ts
+++ b/src/define.ts
@@ -105,7 +105,7 @@ export type Factory<Ctx, TExtensionsMap extends ExtensionsMap > = {
       | {
           description?: string | undefined;
           deprecationReason?: string | undefined;
-          args?: ArgMap<any> | undefined;
+          args?: ArgMap<unknown> | undefined;
         }
       | undefined
   ): AbstractField<Ctx, Out_1>;

--- a/src/define.ts
+++ b/src/define.ts
@@ -105,6 +105,7 @@ export type Factory<Ctx, TExtensionsMap extends ExtensionsMap > = {
       | {
           description?: string | undefined;
           deprecationReason?: string | undefined;
+          args?: ArgMap<any> | undefined;
         }
       | undefined
   ): AbstractField<Ctx, Out_1>;
@@ -343,6 +344,7 @@ export function createTypesFactory<Ctx = undefined, TExtensions extends Extensio
       opts?: {
         description?: string;
         deprecationReason?: string;
+        args?: ArgMap<unknown>;
       }
     ): AbstractField<Ctx, Out> {
       return {
@@ -350,6 +352,7 @@ export function createTypesFactory<Ctx = undefined, TExtensions extends Extensio
         name,
         description: opts && opts.description,
         deprecationReason: opts && opts.deprecationReason,
+        args: opts && opts.args,
         type,
       };
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -119,6 +119,7 @@ export type AbstractField<Ctx, Out> = {
   name: string;
   description?: string;
   deprecationReason?: string;
+  args?: ArgMap<unknown>;
   type: OutputType<Ctx, Out>;
 };
 

--- a/test/simple.js
+++ b/test/simple.js
@@ -1,4 +1,4 @@
-import assert from "assert/strict";
+import assert from "assert";
 import { printSchema } from "graphql";
 import { createTypesFactory, buildGraphQLSchema } from "../dist/cjs/index.js";
 import { createRelayHelpers } from "../dist/cjs/relay.js";
@@ -134,7 +134,12 @@ const characterInterface = t.interfaceType({
     t.abstractField("id", t.NonNull(t.ID)),
     t.abstractField("name", t.NonNull(t.String)),
     t.abstractField("appearsIn", t.NonNull(t.List(t.NonNull(episodeEnum)))),
-    t.abstractField("friends", characterConnectionType),
+    t.abstractField("friends", characterConnectionType, {
+      args: {
+        first: t.arg(t.Int),
+        after: t.arg(t.String),
+      },
+    }),
   ],
 });
 
@@ -337,7 +342,7 @@ interface Character {
   id: ID!
   name: String!
   appearsIn: [Episode!]!
-  friends: CharacterConnection
+  friends(first: Int, after: String): CharacterConnection
 }
 
 """One of the films in the Star Wars Trilogy"""


### PR DESCRIPTION
This allows `abstractField` to take arguments, which in turn allows interface fields to have arguments enforced.

Note: The reason for going `assert/strict` => `assert` is that I couldn't get the tests running locally without changing that. Complains about `assert` not being found.