### PR TITLE
Support defaultValue in inputObjectType fields

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -101,6 +101,7 @@ export function toGraphQLInputType<Ctx>(
           gqlFieldConfig[k] = {
             type: toGraphQLInputType(field.type, typeMap),
             description: field.description,
+            defaultValue: field.defaultValue,
             deprecationReason: field.deprecationReason,
           } as graphql.GraphQLInputFieldConfig;
         });

--- a/src/types.ts
+++ b/src/types.ts
@@ -137,6 +137,7 @@ export type ObjectType<Ctx, Src> = {
 export type InputField<Src> = {
   type: InputType<Src>;
   description?: string;
+  defaultValue?: NonNullable<Src>;
 };
 
 export type InputFieldMap<T> = {


### PR DESCRIPTION
Currently t.inputObjectType's fields cannot take defaultValue's like in the graphql-js lib so I added a couple lines to fix this