### PR TITLE
Fix scalar arguments with default values

### DIFF
--- a/src/define.ts
+++ b/src/define.ts
@@ -82,9 +82,9 @@ export type Factory<Ctx, TExtensionsMap extends ExtensionsMap> = {
   ): Argument<Src>;
   defaultArg<Src>(
     type: InputType<Src>,
-    defaultArg: Exclude<Src, null>,
+    defaultArg: Exclude<Src, null | undefined>,
     description?: string | undefined
-  ): DefaultArgument<Exclude<Src, null>>;
+  ): DefaultArgument<Exclude<Src, null | undefined>>;
 
   field<TKey extends string, Src, Arg, Out>(
     opts: {
@@ -287,9 +287,9 @@ export function createTypesFactory<
     },
     defaultArg<Src>(
       type: InputType<Src>,
-      defaultArg: Exclude<Src, null>,
+      defaultArg: Exclude<Src, null | undefined>,
       description?: string
-    ): DefaultArgument<Exclude<Src, null>> {
+    ): DefaultArgument<Exclude<Src, null | undefined>> {
       return {
         kind: 'DefaultArgument',
         type: type as any,


### PR DESCRIPTION
The change I requested in #63 that was implemented in #65 broke arguments with a default value of scalar types. The reason is that we were excluding `null` from the final type of the arg's value that's passed to the resolver, but since scalars can now be `undefined`, the type had to exclude that possibility too. 