### PR TITLE
Add required resolve function to subscriptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "ts-jest": "27.0.2",
     "ts-node": "^10.0.0",
     "tslib": "^2.1.0",
-    "typescript": "4.3.2"
+    "typescript": "^4.7.4"
   },
   "peerDependencies": {
     "graphql": "^15.1.0"

--- a/src/types.ts
+++ b/src/types.ts
@@ -183,10 +183,10 @@ export type Union<Ctx, Src> = {
 export type SubscriptionObject<Ctx, RootSrc> = {
   kind: 'SubscriptionObject';
   name: string;
-  fields: () => Array<SubscriptionField<Ctx, RootSrc, any, any>>;
+  fields: () => Array<SubscriptionField<Ctx, RootSrc, any, any, any>>;
 };
 
-export type SubscriptionField<Ctx, RootSrc, TArg, Out> = {
+export type SubscriptionField<Ctx, RootSrc, TArg, Event, Out> = {
   kind: 'SubscriptionField';
   name: string;
   description?: string;
@@ -198,9 +198,9 @@ export type SubscriptionField<Ctx, RootSrc, TArg, Out> = {
     args: TOfArgMap<ArgMap<TArg>>,
     ctx: Ctx,
     info: graphql.GraphQLResolveInfo
-  ) => PromiseOrValue<AsyncIterableIterator<Out>>;
+  ) => PromiseOrValue<AsyncIterableIterator<Event>>;
   resolve: (
-    source: Out,
+    source: Event,
     args: TOfArgMap<ArgMap<TArg>>,
     ctx: Ctx,
     info: graphql.GraphQLResolveInfo

--- a/test-api/api.ts
+++ b/test-api/api.ts
@@ -163,24 +163,26 @@ import * as api from '../src';
     subscribe: async function* () {
       yield true;
     },
+    resolve: (p) => p,
   });
 
   t.subscriptionField({
     name: 'foo',
     type: t.Boolean,
-    // @ts-expect-error: subscribe must return number not object with number property
     subscribe: async function* () {
       yield { foo: true };
     },
+    resolve: (p) => p.foo,
   });
 
   t.subscriptionField({
     name: 'foo',
     type: t.Boolean,
-    // @ts-expect-error: subscribe must return number not object with string property
     subscribe: async function* () {
-      yield { foo: 'true' };
+      yield { foo: true };
     },
+    // @ts-expect-error: type { foo: boolean } is not assignable to bool
+    resolve: (p) => p,
   });
 }
 

--- a/test-api/api.ts
+++ b/test-api/api.ts
@@ -157,6 +157,8 @@ import * as api from '../src';
   type Context = unknown;
   const t = api.createTypesFactory<Context>();
 
+  // subscribe yields a type that extends Out
+  // so resolve can be the identity
   t.subscriptionField({
     name: 'foo',
     type: t.Boolean,
@@ -166,22 +168,36 @@ import * as api from '../src';
     resolve: (p) => p,
   });
 
+  // subscribe yields a type that extends Out
+  // so resolve can be omitted
   t.subscriptionField({
     name: 'foo',
     type: t.Boolean,
     subscribe: async function* () {
-      yield { foo: true };
+      yield true;
     },
-    resolve: (p) => p.foo,
   });
 
+  // subscribe yields an Event type that does not extend Out
+  // so resolve must be Event => Out
   t.subscriptionField({
     name: 'foo',
     type: t.Boolean,
     subscribe: async function* () {
-      yield { foo: true };
+      yield { bar: true };
     },
-    // @ts-expect-error: type { foo: boolean } is not assignable to bool
+    resolve: (p) => p.bar,
+  });
+
+  // subscribe yields an Event type that does not extend Out
+  // so this does not type check
+  t.subscriptionField({
+    name: 'foo',
+    type: t.Boolean,
+    subscribe: async function* () {
+      yield { bar: true };
+    },
+    // @ts-expect-error: type { bar: boolean } is not assignable to bool
     resolve: (p) => p,
   });
 }

--- a/test/simple.spec.ts
+++ b/test/simple.spec.ts
@@ -507,6 +507,7 @@ test('Subscription work properly', async () => {
             yield greeting;
           }
         },
+        resolve: (p) => p,
       }),
     ],
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2936,10 +2936,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.2.tgz#399ab18aac45802d6f2498de5054fcbbe716a805"
-  integrity sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==
+typescript@^4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 universalify@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
This adds a resolve function to subscription fields. 

As per [the spec](https://spec.graphql.org/June2018/#sec-Source-Stream), [`graphql-js` calls resolve on each event in the stream](https://github.com/graphql/graphql-js/blob/cfbc023296a1a596429a6312abede040c9353644/src/execution/execute.ts#L1163-L1166) returned by subscribe. However, when using the type factory in `gqtx` the [resolve function is just the identity](https://github.com/sikanhe/gqtx/blob/418ce4f079fd74eed31d015f28c8058efe731112/src/define.ts#L506).

In other words, if subscribe yields values of type `Event` that are not compatible with the field type (`Out`), we need to be able to supply `resolve` to map from `Event` to `Out`.

A neater and non-breaking solution would be to only require the resolve function if the type of the event in the stream is not compatible with the output type of the field, but I was unable to get that working using an `Event extends Out ? ...` trick similar to how the resolve function is optional for fields if `Src[TKey] extends Out`.

An attempt at making it optional is here https://github.com/mbirkegaard/gqtx/commit/c1355124fe72d5ef516659cf9027da31d22e071e, but various attempts failed with the compiler error 
```
'Out' could be instantiated with an arbitrary type which could be unrelated to 'Event'
```
despite `Event extends Out`