### PR TITLE
fix: prevent resolver from widening output type

### DIFF
--- a/src/define.ts
+++ b/src/define.ts
@@ -31,13 +31,15 @@ type ExtensionsMap = {
   };
 };
 
+type NoInfer<T> = [T][T extends any ? 0 : never];
+
 type ResolvePartialMandatory<Src, Arg, Out> = {
   resolve: (
     src: Src,
     args: TOfArgMap<ArgMap<Arg>>,
     ctx: GqlContext,
     info: graphql.GraphQLResolveInfo
-  ) => PromiseOrValue<Out>;
+  ) => PromiseOrValue<NoInfer<Out>>;
 };
 
 type ResolvePartialOptional<Src, Arg, Out> = {
@@ -46,7 +48,7 @@ type ResolvePartialOptional<Src, Arg, Out> = {
     args: TOfArgMap<ArgMap<Arg>>,
     ctx: GqlContext,
     info: graphql.GraphQLResolveInfo
-  ) => PromiseOrValue<Out>;
+  ) => PromiseOrValue<NoInfer<Out>>;
 };
 
 function builtInScalar<Src>(

--- a/test-api/api.ts
+++ b/test-api/api.ts
@@ -234,3 +234,25 @@ declare module '../src/types.js' {
     fields: () => [],
   });
 }
+
+{
+  type Foo = { foo: string };
+  type Bar = { bar: string };
+
+  const FooType = Gql.Object<Foo>({
+    name: 'Foo',
+    fields: () => [
+      Gql.Field({
+        name: 'foo',
+        type: Gql.NonNull(Gql.String),
+      }),
+    ],
+  });
+
+  Gql.Field({
+    name: 'getFoo',
+    type: Gql.NonNull(FooType),
+    // @ts-expect-error: Type 'Foo | Bar' is not assignable to type 'PromiseOrValue<Foo>'.
+    resolve: () => ({ bar: 'bar' } as Foo | Bar),
+  });
+}


### PR DESCRIPTION
If the resolver for a field returns a union where one of the constituents satisfies the expected type, then TypeScript widens the `Out` type to allow the union, but the resolver's type should be limited to what the `type` option allows. Adding this `NoInfer` utility prevents TypeScript from widening the type in this case.