### PR TITLE
Fix CJS type import when moduleResolution is node16

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,15 +7,26 @@
   "types": "index.d.ts",
   "exports": {
     ".": {
-      "import": "./index.js",
-      "require": "./cjs/index.cjs"
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./index.js"
+      },
+      "require": {
+        "types": "./cjs/index.d.ts",
+        "default": "./cjs/index.cjs"
+      }
     },
     "./relay": {
-      "import": "./relay.js",
-      "require": "./cjs/relay.cjs"
+      "import": {
+        "types": "./relay.d.ts",
+        "default": "./relay.js"
+      },
+      "require": {
+        "types": "./cjs/relay.d.ts",
+        "default": "./cjs/relay.cjs"
+      }
     },
-    "./package.json": "./package.json",
-    "./": "./"
+    "./package.json": "./package.json"
   },
   "repository": {
     "type": "git",

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/cjs",
-    "declaration": false
+    "outDir": "dist/cjs"
   }
 }


### PR DESCRIPTION
The types right now currently don't work if the user is using node16 moduleResolution in a CJS project:
https://arethetypeswrong.github.io/?p=gqtx%400.9.3

After running `yarn build && cd dist && npx @arethetypeswrong/cli --pack` with this change:

<img width="498" alt="image" src="https://github.com/sikanhe/gqtx/assets/739172/70c93cda-ca35-4131-87b6-3831eb90cd0b">
